### PR TITLE
Add conditional VPC resource creation based on vpc_id

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,10 +1,14 @@
 data "uname" "localhost" {}
 
 data "aws_vpc" "this" {
+  count = var.vpc_id == null ? 0 : 1
+
   id = var.vpc_id
 }
 
 data "aws_subnets" "this" {
+  count = var.vpc_id == null ? 0 : 1
+
   filter {
     name   = "vpc-id"
     values = [var.vpc_id]

--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ resource "aws_lambda_function" "lambda" {
     for_each = var.vpc_id == null ? [] : [{}]
     content {
       security_group_ids          = [for sg in aws_security_group.this : sg.id]
-      subnet_ids                  = data.aws_subnets.this.ids
+      subnet_ids                  = data.aws_subnets.this[0].ids
       ipv6_allowed_for_dual_stack = true
     }
   }

--- a/network.tf
+++ b/network.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "this" {
-  for_each = { for sg in var.security_groups : sg.name => sg }
+  for_each = var.vpc_id == null ? {} : { for sg in var.security_groups : sg.name => sg }
 
   name_prefix = "${each.key}-"
   description = each.value.description
-  vpc_id      = data.aws_vpc.this.id
+  vpc_id      = data.aws_vpc.this[0].id
 
   tags = merge(
     {
@@ -14,7 +14,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this_ipv4" {
-  for_each = { for rule in local.ipv4_rules_ingress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
+  for_each = var.vpc_id == null ? {} : { for rule in local.ipv4_rules_ingress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
   cidr_ipv4         = each.value.cidr_block
@@ -24,7 +24,7 @@ resource "aws_vpc_security_group_ingress_rule" "this_ipv4" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this_ipv6" {
-  for_each = { for rule in local.ipv6_rules_ingress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
+  for_each = var.vpc_id == null ? {} : { for rule in local.ipv6_rules_ingress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
   cidr_ipv6         = each.value.cidr_block
@@ -34,7 +34,7 @@ resource "aws_vpc_security_group_ingress_rule" "this_ipv6" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "this_ipv4" {
-  for_each = { for rule in local.ipv4_rules_egress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
+  for_each = var.vpc_id == null ? {} : { for rule in local.ipv4_rules_egress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
   cidr_ipv4         = each.value.cidr_block
@@ -44,7 +44,7 @@ resource "aws_vpc_security_group_egress_rule" "this_ipv4" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "this_ipv6" {
-  for_each = { for rule in local.ipv6_rules_egress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
+  for_each = var.vpc_id == null ? {} : { for rule in local.ipv6_rules_egress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
   cidr_ipv6         = each.value.cidr_block


### PR DESCRIPTION
Updated Terraform configuration to conditionally create VPC-related data sources and resources only when var.vpc_id is set. This prevents errors when vpc_id is null by using count and for_each expressions, and updates references to use indexed data sources accordingly.