### PR TITLE
Add support for Go build tags in build command

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,8 @@ locals {
   is_linux           = data.uname.localhost.operating_system != "windows"
   build_output_file  = "./tf_generated/${var.name}/bootstrap"
   build_input_file   = "${trimsuffix(var.code_dir, "/")}/${var.main_filename}"
-  build_command      = local.is_linux ? "cd ${var.code_dir} && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='-s -w' -o \"${abspath(local.build_output_file)}\" \"${abspath(local.build_input_file)}\"" : "$Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; cd \"${var.code_dir}\"; go mod tidy; go build -o \"${abspath(local.build_output_file)}\" \"${abspath(local.build_input_file)}\""
+  build_tags         = join(" ", var.go_build_tags)
+  build_command      = local.is_linux ? "cd ${var.code_dir} && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='-s -w' -tags \"${local.build_tags}\" -o \"${abspath(local.build_output_file)}\" \"${abspath(local.build_input_file)}\"" : "$Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; cd \"${var.code_dir}\"; go mod tidy; go build \"${local.build_tags}\" -o \"${abspath(local.build_output_file)}\" \"${abspath(local.build_input_file)}\""
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,9 @@ variable "vpc_id" {
   type        = string
   default     = null
 }
+
+variable "go_build_tags" {
+  description = "Build tags for go build command"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Introduces a new variable `go_build_tags` to allow specifying build tags for the Go build process. Updates the build command in `locals.tf` to include these tags for both Linux and Windows environments.