### PR TITLE
Refactor security group rules to unified structure

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -15,46 +15,46 @@ locals {
 locals {
   ipv4_rules_ingress = flatten([
     for sg in var.security_groups : [
-      for rule in sg.ingress_rules : {
+      for rule in sg.rules : {
         security_group_name = sg.name
         from_port           = lookup(rule, "from_port", null)
         to_port             = lookup(rule, "to_port", null)
         ip_protocol         = rule.ip_protocol
-        cidr_block          = rule.cidr_block
-      } if rule.type == "ipv4"
+        cidr_blocks         = rule.ipv4_cidr_blocks
+      } if rule.type == "ingress"
     ]
   ])
   ipv6_rules_ingress = flatten([
     for sg in var.security_groups : [
-      for rule in sg.ingress_rules : {
+      for rule in sg.rules : {
         security_group_name = sg.name
         from_port           = lookup(rule, "from_port", null)
         to_port             = lookup(rule, "to_port", null)
         ip_protocol         = rule.ip_protocol
-        cidr_block          = rule.cidr_block
-      } if rule.type == "ipv6"
+        cidr_blocks         = rule.ipv6_cidr_blocks
+      } if rule.type == "ingress"
     ]
   ])
   ipv4_rules_egress = flatten([
     for sg in var.security_groups : [
-      for rule in sg.egress_rules : {
+      for rule in sg.rules : {
         security_group_name = sg.name
         from_port           = lookup(rule, "from_port", null)
         to_port             = lookup(rule, "to_port", null)
         ip_protocol         = rule.ip_protocol
-        cidr_block          = rule.cidr_block
-      } if rule.type == "ipv4"
+        cidr_blocks         = rule.ipv4_cidr_blocks
+      } if rule.type == "egress"
     ]
   ])
   ipv6_rules_egress = flatten([
     for sg in var.security_groups : [
-      for rule in sg.egress_rules : {
+      for rule in sg.rules : {
         security_group_name = sg.name
         from_port           = lookup(rule, "from_port", null)
         to_port             = lookup(rule, "to_port", null)
         ip_protocol         = rule.ip_protocol
-        cidr_block          = rule.cidr_block
-      } if rule.type == "ipv6"
+        cidr_blocks         = rule.ipv6_cidr_blocks
+      } if rule.type == "egress"
     ]
   ])
 }

--- a/network.tf
+++ b/network.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "this" {
-  for_each = { for sg in var.security_groups : sg.name => sg }
+  for_each = var.vpc_id == null ? {} : { for sg in var.security_groups : sg.name => sg }
 
   name_prefix = "${each.key}-"
   description = each.value.description
-  vpc_id      = data.aws_vpc.this.id
+  vpc_id      = data.aws_vpc.this[0].id
 
   tags = merge(
     {
@@ -14,7 +14,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this_ipv4" {
-  for_each = {
+  for_each = var.vpc_id == null ? {} : {
     for pair in flatten([
       for rule in local.ipv4_rules_ingress : [
         for cidr in rule.cidr_blocks : {
@@ -33,7 +33,7 @@ resource "aws_vpc_security_group_ingress_rule" "this_ipv4" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this_ipv6" {
-  for_each = {
+  for_each = var.vpc_id == null ? {} : {
     for pair in flatten([
       for rule in local.ipv6_rules_ingress : [
         for cidr in rule.cidr_blocks : {
@@ -52,7 +52,7 @@ resource "aws_vpc_security_group_ingress_rule" "this_ipv6" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "this_ipv4" {
-  for_each = {
+  for_each = var.vpc_id == null ? {} : {
     for pair in flatten([
       for rule in local.ipv4_rules_egress : [
         for cidr in rule.cidr_blocks : {
@@ -71,7 +71,7 @@ resource "aws_vpc_security_group_egress_rule" "this_ipv4" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "this_ipv6" {
-  for_each = {
+  for_each = var.vpc_id == null ? {} : {
     for pair in flatten([
       for rule in local.ipv6_rules_egress : [
         for cidr in rule.cidr_blocks : {

--- a/network.tf
+++ b/network.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "this" {
-  for_each = var.vpc_id == null ? {} : { for sg in var.security_groups : sg.name => sg }
+  for_each = { for sg in var.security_groups : sg.name => sg }
 
   name_prefix = "${each.key}-"
   description = each.value.description
-  vpc_id      = data.aws_vpc.this[0].id
+  vpc_id      = data.aws_vpc.this.id
 
   tags = merge(
     {
@@ -14,7 +14,16 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this_ipv4" {
-  for_each = var.vpc_id == null ? {} : { for rule in local.ipv4_rules_ingress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
+  for_each = {
+    for pair in flatten([
+      for rule in local.ipv4_rules_ingress : [
+        for cidr in rule.cidr_blocks : {
+          key   = "${rule.security_group_name}-${rule.ip_protocol}-${replace(cidr, "/", "-")}"
+          value = merge(rule, { cidr_block = cidr })
+        }
+      ]
+    ]) : pair.key => pair.value
+  }
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
   cidr_ipv4         = each.value.cidr_block
@@ -24,7 +33,16 @@ resource "aws_vpc_security_group_ingress_rule" "this_ipv4" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this_ipv6" {
-  for_each = var.vpc_id == null ? {} : { for rule in local.ipv6_rules_ingress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
+  for_each = {
+    for pair in flatten([
+      for rule in local.ipv6_rules_ingress : [
+        for cidr in rule.cidr_blocks : {
+          key   = "${rule.security_group_name}-${rule.ip_protocol}-${replace(cidr, "/", "-")}"
+          value = merge(rule, { cidr_block = cidr })
+        }
+      ]
+    ]) : pair.key => pair.value
+  }
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
   cidr_ipv6         = each.value.cidr_block
@@ -34,7 +52,16 @@ resource "aws_vpc_security_group_ingress_rule" "this_ipv6" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "this_ipv4" {
-  for_each = var.vpc_id == null ? {} : { for rule in local.ipv4_rules_egress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
+  for_each = {
+    for pair in flatten([
+      for rule in local.ipv4_rules_egress : [
+        for cidr in rule.cidr_blocks : {
+          key   = "${rule.security_group_name}-${rule.ip_protocol}-${replace(cidr, "/", "-")}"
+          value = merge(rule, { cidr_block = cidr })
+        }
+      ]
+    ]) : pair.key => pair.value
+  }
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
   cidr_ipv4         = each.value.cidr_block
@@ -44,7 +71,16 @@ resource "aws_vpc_security_group_egress_rule" "this_ipv4" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "this_ipv6" {
-  for_each = var.vpc_id == null ? {} : { for rule in local.ipv6_rules_egress : "${rule.security_group_name}-${rule.ip_protocol}-${replace(rule.cidr_block, "/", "-")}" => rule }
+  for_each = {
+    for pair in flatten([
+      for rule in local.ipv6_rules_egress : [
+        for cidr in rule.cidr_blocks : {
+          key   = "${rule.security_group_name}-${rule.ip_protocol}-${replace(cidr, "/", "-")}"
+          value = merge(rule, { cidr_block = cidr })
+        }
+      ]
+    ]) : pair.key => pair.value
+  }
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
   cidr_ipv6         = each.value.cidr_block
@@ -52,4 +88,3 @@ resource "aws_vpc_security_group_egress_rule" "this_ipv6" {
   ip_protocol       = each.value.ip_protocol
   to_port           = each.value.to_port
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -65,12 +65,12 @@ variable "security_groups" {
     name        = string
     description = string
     rules = list(object({
-      type              = string
-      from_port         = optional(number)
-      to_port           = optional(number)
-      ip_protocol       = string
-      ipv4_cidr_blocks  = list(string)
-      ipv6_cidr_blocks  = list(string)
+      type             = string
+      from_port        = optional(number)
+      to_port          = optional(number)
+      ip_protocol      = string
+      ipv4_cidr_blocks = list(string)
+      ipv6_cidr_blocks = list(string)
     }))
   }))
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -64,29 +64,22 @@ variable "security_groups" {
   type = list(object({
     name        = string
     description = string
-    ingress_rules = list(object({
-      type        = string
-      from_port   = optional(number)
-      to_port     = optional(number)
-      ip_protocol = string
-      cidr_block  = string
-    }))
-    egress_rules = list(object({
-      type        = string
-      from_port   = optional(number)
-      to_port     = optional(number)
-      ip_protocol = string
-      cidr_block  = string
+    rules = list(object({
+      type              = string
+      from_port         = optional(number)
+      to_port           = optional(number)
+      ip_protocol       = string
+      ipv4_cidr_blocks  = list(string)
+      ipv6_cidr_blocks  = list(string)
     }))
   }))
   validation {
     condition = alltrue([
       for sg in var.security_groups : alltrue([
-        alltrue([for rule in sg.ingress_rules : contains(["ipv4", "ipv6"], rule.type)]),
-        alltrue([for rule in sg.egress_rules : contains(["ipv4", "ipv6"], rule.type)])
+        alltrue([for rule in sg.rules : contains(["egress", "ingress"], rule.type)])
       ])
     ])
-    error_message = "Each rule.type must be either 'ipv4' or 'ipv6'."
+    error_message = "Each rule.type must be either 'egress' or 'ingress'."
   }
   default = []
 }


### PR DESCRIPTION
Consolidates ingress and egress rules into a single 'rules' list per security group, supporting both IPv4 and IPv6 CIDR blocks. Updates locals, variables, and resource definitions to handle the new structure and allow multiple CIDR blocks per rule. This improves flexibility and simplifies rule management.