### PR TITLE
Simplify Go Lambda build command and remove main_filename var

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -3,9 +3,8 @@ locals {
   is_go_build_lambda = var.runtime == "provided.al2" && var.handler == null
   is_linux           = data.uname.localhost.operating_system != "windows"
   build_output_file  = "./tf_generated/${var.name}/bootstrap"
-  build_input_file   = "${trimsuffix(var.code_dir, "/")}/${var.main_filename}"
   build_tags         = join(" ", var.go_build_tags)
-  build_command      = local.is_linux ? "cd ${var.code_dir} && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='-s -w' -tags \"${local.build_tags}\" -o \"${abspath(local.build_output_file)}\" \"${abspath(local.build_input_file)}\"" : "$Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; cd \"${var.code_dir}\"; go mod tidy; go build -tags \"${local.build_tags}\" -o \"${abspath(local.build_output_file)}\" \"${abspath(local.build_input_file)}\""
+  build_command      = local.is_linux ? "cd ${var.code_dir} && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='-s -w' -tags \"${local.build_tags}\" -o \"${abspath(local.build_output_file)}\" ." : "$Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; cd \"${var.code_dir}\"; go mod tidy; go build -tags \"${local.build_tags}\" -o \"${abspath(local.build_output_file)}\" ."
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,6 @@ resource "terraform_data" "build" {
 
   triggers_replace = {
     dir_sha1    = sha1(join("", [for f in fileset(var.code_dir, "*") : filesha1("${var.code_dir}/${f}")]))
-    file_exists = fileexists(local.build_input_file)
   }
 
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "terraform_data" "build" {
   count = local.is_go_build_lambda ? 1 : 0
 
   triggers_replace = {
-    dir_sha1    = sha1(join("", [for f in fileset(var.code_dir, "*") : filesha1("${var.code_dir}/${f}")]))
+    dir_sha1 = sha1(join("", [for f in fileset(var.code_dir, "*") : filesha1("${var.code_dir}/${f}")]))
   }
 
   provisioner "local-exec" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,12 +14,6 @@ variable "handler" {
   description = "Lambda handler"
 }
 
-variable "main_filename" {
-  type        = string
-  description = "Main filename of the lambda function (only needed for go Lambda functions)"
-  default     = "main.go"
-}
-
 variable "runtime" {
   type        = string
   default     = "provided.al2"


### PR DESCRIPTION
The build command now uses '.' as the build target instead of referencing a specific main file, aligning with standard Go build practices. The unused 'main_filename' variable has been removed from variables.tf.