### PR TITLE
Add VPC network interface permissions to Lambda policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,18 @@ data "aws_iam_policy_document" "lambda" {
   }
 
   dynamic "statement" {
+    for_each = var.vpc_networked ? [{}] : []
+    content {
+      actions = [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ]
+      resources = ["*"]
+    }
+  }
+
+  dynamic "statement" {
     for_each = var.enable_tracing ? [{}] : []
     content {
       actions = [


### PR DESCRIPTION
Grants Lambda permissions to manage EC2 network interfaces when 'vpc_networked' variable is true. This enables Lambda functions to operate within a VPC by allowing necessary EC2 actions.