### PR TITLE
Add vpc_dualstack variable for Lambda dual-stack support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "aws_lambda_function" "lambda" {
     content {
       security_group_ids          = [for sg in aws_security_group.this : sg.id]
       subnet_ids                  = data.aws_subnets.this[0].ids
-      ipv6_allowed_for_dual_stack = true
+      ipv6_allowed_for_dual_stack = var.vpc_dualstack
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,12 @@ variable "vpc_networked" {
   default     = false
 }
 
+variable "vpc_dualstack" {
+  description = "Whether to deploy the lambda function in a dualstack VPC (IPv4 and IPv6). Only used if vpc_networked is true."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
   description = "The ID of the VPC where the lambda function will be deployed"
   type        = string


### PR DESCRIPTION
Introduces a new variable 'vpc_dualstack' to control whether the Lambda function is deployed in a dual-stack VPC (IPv4 and IPv6). Updates the Lambda resource to use this variable for the ipv6_allowed_for_dual_stack property.