### PR TITLE
Refactor subnet handling for Lambda deployment

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -5,12 +5,3 @@ data "aws_vpc" "this" {
 
   id = var.vpc_id
 }
-
-data "aws_subnets" "this" {
-  count = var.vpc_networked ? 1 : 0
-
-  filter {
-    name   = "vpc-id"
-    values = [var.vpc_id]
-  }
-}

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_lambda_function" "lambda" {
     for_each = var.vpc_id == null ? [] : [{}]
     content {
       security_group_ids          = [for sg in aws_security_group.this : sg.id]
-      subnet_ids                  = data.aws_subnets.this[0].ids
+      subnet_ids                  = var.subnet_ids
       ipv6_allowed_for_dual_stack = var.vpc_dualstack
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "vpc_id" {
   default     = null
 }
 
+variable "subnet_ids" {
+  description = "The IDs of the subnets where the lambda function will be deployed"
+  type        = list(string)
+  default     = []
+}
+
 variable "go_build_tags" {
   description = "Build tags for go build command"
   type        = list(string)


### PR DESCRIPTION
Removes the aws_subnets data source and introduces a new 'subnet_ids' variable to explicitly specify subnet IDs for Lambda functions. Updates the Lambda resource to use this variable, improving flexibility and clarity in subnet selection.