### PR TITLE
Include subdirectories in fileset for build trigger

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "terraform_data" "build" {
   count = local.is_go_build_lambda ? 1 : 0
 
   triggers_replace = {
-    dir_sha1 = sha1(join("", [for f in fileset(var.code_dir, "*") : filesha1("${var.code_dir}/${f}")]))
+    dir_sha1 = sha1(join("", [for f in fileset(var.code_dir, "**") : filesha1("${var.code_dir}/${f}")]))
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
Changed fileset pattern from '*' to '**' in the build resource to ensure files in subdirectories are included when calculating the directory SHA1. This improves trigger accuracy for changes in nested code files.