### PR TITLE
Improve build output path handling in locals.tf

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,15 +4,15 @@ locals {
   is_linux           = data.uname.localhost.operating_system != "windows"
 
   # Calculate relative path from code_dir to output
-  build_output_dir   = abspath("./tf_generated/${var.name}")
-  build_output_file  = "${local.build_output_dir}/bootstrap"
-  build_tags         = join(" ", var.go_build_tags)
+  build_output_dir  = abspath("./tf_generated/${var.name}")
+  build_output_file = "${local.build_output_dir}/bootstrap"
+  build_tags        = join(" ", var.go_build_tags)
 
   # Construct ldflags string from map
-  base_ldflags      = "-s -w"
-  x_flags           = [for key, value in var.go_additional_ldflags : "-X ${key}=${value}"]
-  custom_ldflags    = join(" ", local.x_flags)
-  combined_ldflags  = local.custom_ldflags != "" ? "${local.base_ldflags} ${local.custom_ldflags}" : local.base_ldflags
+  base_ldflags     = "-s -w"
+  x_flags          = [for key, value in var.go_additional_ldflags : "-X ${key}=${value}"]
+  custom_ldflags   = join(" ", local.x_flags)
+  combined_ldflags = local.custom_ldflags != "" ? "${local.base_ldflags} ${local.custom_ldflags}" : local.base_ldflags
 
   # Build commands with proper directory handling
   build_command = local.is_linux ? "mkdir -p \"${local.build_output_dir}\" && cd ${var.code_dir} && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${local.build_output_file}\" ." : "New-Item -ItemType Directory -Force -Path \"${local.build_output_dir}\" | Out-Null; $Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; cd \"${var.code_dir}\"; go mod tidy; go build -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${local.build_output_file}\" ."

--- a/locals.tf
+++ b/locals.tf
@@ -2,17 +2,20 @@ locals {
   elements           = split("/", trimsuffix(var.code_dir, "/"))
   is_go_build_lambda = var.runtime == "provided.al2" && var.handler == null
   is_linux           = data.uname.localhost.operating_system != "windows"
-  build_output_file  = "./tf_generated/${var.name}/bootstrap"
+
+  # Calculate relative path from code_dir to output
+  build_output_dir   = abspath("./tf_generated/${var.name}")
+  build_output_file  = "${local.build_output_dir}/bootstrap"
   build_tags         = join(" ", var.go_build_tags)
 
   # Construct ldflags string from map
-  base_ldflags     = "-s -w"
-  x_flags          = [for key, value in var.go_additional_ldflags : "-X ${key}=${value}"]
-  custom_ldflags   = join(" ", local.x_flags)
-  combined_ldflags = local.custom_ldflags != "" ? "${local.base_ldflags} ${local.custom_ldflags}" : local.base_ldflags
+  base_ldflags      = "-s -w"
+  x_flags           = [for key, value in var.go_additional_ldflags : "-X ${key}=${value}"]
+  custom_ldflags    = join(" ", local.x_flags)
+  combined_ldflags  = local.custom_ldflags != "" ? "${local.base_ldflags} ${local.custom_ldflags}" : local.base_ldflags
 
-  # Build commands with ldflags support
-  build_command = local.is_linux ? "cd ${var.code_dir} && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${abspath(local.build_output_file)}\" ." : "$Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; cd \"${var.code_dir}\"; go mod tidy; go build -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${abspath(local.build_output_file)}\" ."
+  # Build commands with proper directory handling
+  build_command = local.is_linux ? "mkdir -p \"${local.build_output_dir}\" && cd ${var.code_dir} && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${local.build_output_file}\" ." : "New-Item -ItemType Directory -Force -Path \"${local.build_output_dir}\" | Out-Null; $Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; cd \"${var.code_dir}\"; go mod tidy; go build -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${local.build_output_file}\" ."
 }
 
 locals {


### PR DESCRIPTION
Refactored build output directory and file path calculation to use abspath and ensure output directories are created before building. Updated build_command for both Linux and Windows to handle directory creation, improving reliability of build process.