### PR TITLE
Refactor Go build command for safer output handling

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -3,9 +3,10 @@ locals {
   is_go_build_lambda = var.runtime == "provided.al2" && var.handler == null
   is_linux           = data.uname.localhost.operating_system != "windows"
 
-  # Calculate relative path from code_dir to output
+  abs_code_dir      = abspath(var.code_dir)
   build_output_dir  = abspath("./tf_generated/${var.name}")
   build_output_file = "${local.build_output_dir}/bootstrap"
+  temp_bootstrap    = "bootstrap_${var.name}"
   build_tags        = join(" ", var.go_build_tags)
 
   # Construct ldflags string from map
@@ -14,8 +15,8 @@ locals {
   custom_ldflags   = join(" ", local.x_flags)
   combined_ldflags = local.custom_ldflags != "" ? "${local.base_ldflags} ${local.custom_ldflags}" : local.base_ldflags
 
-  # Build commands with proper directory handling
-  build_command = local.is_linux ? "mkdir -p \"${local.build_output_dir}\" && cd ${var.code_dir} && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${local.build_output_file}\" ." : "New-Item -ItemType Directory -Force -Path \"${local.build_output_dir}\" | Out-Null; $Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; cd \"${var.code_dir}\"; go mod tidy; go build -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${local.build_output_file}\" ."
+  # Build in module dir, then move to target location
+  build_command = local.is_linux ? "cd \"${local.abs_code_dir}\" && go mod tidy && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-trimpath go build -mod=readonly -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${local.temp_bootstrap}\" . && mkdir -p \"${local.build_output_dir}\" && mv \"${local.temp_bootstrap}\" \"${local.build_output_file}\"" : "cd \"${local.abs_code_dir}\"; $Env:GOOS=\"linux\"; $Env:GOARCH=\"amd64\"; go mod tidy; go build -ldflags='${local.combined_ldflags}' -tags \"${local.build_tags}\" -o \"${local.temp_bootstrap}\" .; New-Item -ItemType Directory -Force -Path \"${local.build_output_dir}\" | Out-Null; Move-Item -Force \"${local.temp_bootstrap}\" \"${local.build_output_file}\""
 }
 
 locals {


### PR DESCRIPTION
Builds the Go binary in the module directory as a temporary file before moving it to the target output directory. This prevents accidental overwrites and ensures proper directory handling for both Linux and Windows environments.