### PR TITLE
Add support for deploying pre-built Go zip

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,8 @@
 locals {
   elements           = split("/", trimsuffix(var.code_dir, "/"))
   is_go_build_lambda = var.runtime == "provided.al2" && var.handler == null
+  should_build       = local.is_go_build_lambda && var.pre_built_zip == null
+  pre_built_zip_hash = var.pre_built_zip != null ? filebase64sha256(var.pre_built_zip) : ""
   is_linux           = data.uname.localhost.operating_system != "windows"
   build_output_file  = "./tf_generated/${var.name}/bootstrap"
   build_tags         = join(" ", var.go_build_tags)

--- a/main.tf
+++ b/main.tf
@@ -118,21 +118,21 @@ data "archive_file" "build" {
 
 resource "aws_lambda_function" "lambda" {
   filename = (
-    local.should_build        ? data.archive_file.build[0].output_path :
+    local.should_build ? data.archive_file.build[0].output_path :
     var.pre_built_zip != null ? var.pre_built_zip :
-                                data.archive_file.non_build[0].output_path
+    data.archive_file.non_build[0].output_path
   )
   function_name = var.name
   role          = aws_iam_role.lambda.arn
   handler       = local.is_go_build_lambda ? "bootstrap" : var.handler
   runtime       = var.runtime
   source_code_hash = (
-    local.should_build        ? data.archive_file.build[0].output_base64sha256 :
+    local.should_build ? data.archive_file.build[0].output_base64sha256 :
     var.pre_built_zip != null ? local.pre_built_zip_hash :
-                                data.archive_file.non_build[0].output_base64sha256
+    data.archive_file.non_build[0].output_base64sha256
   )
-  timeout          = var.timeout
-  layers           = var.layer_arns
+  timeout = var.timeout
+  layers  = var.layer_arns
 
   logging_config {
     log_format            = var.json_logging ? "JSON" : "Text"

--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ resource "aws_iam_role_policy_attachment" "lambda_logs" {
 }
 
 resource "terraform_data" "build" {
-  count = local.is_go_build_lambda ? 1 : 0
+  count = local.should_build ? 1 : 0
 
   triggers_replace = {
     dir_sha1 = sha1(join("", [for f in fileset(var.code_dir, "**") : filesha1("${var.code_dir}/${f}")]))
@@ -105,7 +105,7 @@ data "archive_file" "non_build" {
 }
 
 data "archive_file" "build" {
-  count = local.is_go_build_lambda ? 1 : 0
+  count = local.should_build ? 1 : 0
 
   type        = "zip"
   source_file = local.build_output_file
@@ -117,12 +117,20 @@ data "archive_file" "build" {
 }
 
 resource "aws_lambda_function" "lambda" {
-  filename         = local.is_go_build_lambda ? data.archive_file.build[0].output_path : data.archive_file.non_build[0].output_path
-  function_name    = var.name
-  role             = aws_iam_role.lambda.arn
-  handler          = local.is_go_build_lambda ? "bootstrap" : var.handler
-  runtime          = var.runtime
-  source_code_hash = local.is_go_build_lambda ? data.archive_file.build[0].output_base64sha256 : data.archive_file.non_build[0].output_base64sha256
+  filename = (
+    local.should_build        ? data.archive_file.build[0].output_path :
+    var.pre_built_zip != null ? var.pre_built_zip :
+                                data.archive_file.non_build[0].output_path
+  )
+  function_name = var.name
+  role          = aws_iam_role.lambda.arn
+  handler       = local.is_go_build_lambda ? "bootstrap" : var.handler
+  runtime       = var.runtime
+  source_code_hash = (
+    local.should_build        ? data.archive_file.build[0].output_base64sha256 :
+    var.pre_built_zip != null ? local.pre_built_zip_hash :
+                                data.archive_file.non_build[0].output_base64sha256
+  )
   timeout          = var.timeout
   layers           = var.layer_arns
 

--- a/variables.tf
+++ b/variables.tf
@@ -147,3 +147,9 @@ variable "go_additional_ldflags" {
   type        = map(string)
   default     = {}
 }
+
+variable "pre_built_zip" {
+  description = "Path to a pre-built zip file to deploy directly. When set, all Go build logic is skipped and this zip is used as the Lambda package. Only valid when runtime == \"provided.al2\" and handler == null."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Introduce a new variable `pre_built_zip` to allow deploying a pre-built Lambda zip instead of running the in-module Go build. Add `local.should_build` and `local.pre_built_zip_hash` to decide whether to run the build and to compute the SHA256 of the provided zip. Update counts for build-related data resources and adjust aws_lambda_function `filename` and `source_code_hash` to prefer the pre-built zip when provided (and skip build when appropriate). This keeps existing behavior for non-Go builds or when no pre-built zip is supplied.