### PR TITLE
feat: Support provided.al2023 for Go build lambda

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   elements           = split("/", trimsuffix(var.code_dir, "/"))
-  is_go_build_lambda = var.runtime == "provided.al2" && var.handler == null
+  is_go_build_lambda = contains(["provided.al2", "provided.al2023"], var.runtime) && var.handler == null
   should_build       = local.is_go_build_lambda && var.pre_built_zip == null
   pre_built_zip_hash = var.pre_built_zip != null ? filebase64sha256(var.pre_built_zip) : ""
   is_linux           = data.uname.localhost.operating_system != "windows"


### PR DESCRIPTION
Update the is_go_build_lambda local to treat both provided.al2 and provided.al2023 as custom runtimes for Go build detection. Uses contains([...], var.runtime) and keeps the handler==null check so pre_built_zip and should_build logic continue to behave the same for the newer AL2023 runtime.